### PR TITLE
Fix quoted printable decoding bug

### DIFF
--- a/utils/url_processing/decoder.py
+++ b/utils/url_processing/decoder.py
@@ -127,8 +127,8 @@ class UrlDecoder:
                 # Only decode if it looks like quoted-printable
                 if re.search(r'=[0-9A-F]{2}', text):
                     encoded_text = text.encode('utf-8', errors='replace')
-                    decoded_text = quopri.decode(encoded_text)
-                    text = decoded_text.decode('utf-8', errors='replace')
+                    decoded_bytes = quopri.decodestring(encoded_text)
+                    text = decoded_bytes.decode('utf-8', errors='replace')
             
             return text
         except Exception as e:


### PR DESCRIPTION
## Summary
- fix incorrect call to `quopri.decode` in decoder

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b1245e84832499eb2eeb6857d2fc