### PR TITLE
Fix recursion handling for RFC822 attachments

### DIFF
--- a/extractors/attachment_extractor.py
+++ b/extractors/attachment_extractor.py
@@ -39,13 +39,13 @@ def extract_attachments(msg, depth=0, max_depth=10, container_path=None, stop_re
                     
                 # Check if it's an attachment
                 if is_attachment(part):
-                    attachment = process_attachment(part, depth, max_depth, container_path)
+                    attachment = process_attachment(part, depth, max_depth, container_path, stop_recursion)
                     if attachment:
                         attachments.append(attachment)
         
         # Handle single part message with attachment
         elif is_attachment(msg):
-            attachment = process_attachment(msg, depth, max_depth, container_path)
+            attachment = process_attachment(msg, depth, max_depth, container_path, stop_recursion)
             if attachment:
                 attachments.append(attachment)
         
@@ -230,7 +230,7 @@ def get_filename(part):
     
     return ""
 
-def process_attachment(part, depth, max_depth, container_path):
+def process_attachment(part, depth, max_depth, container_path, stop_recursion=False):
     """
     Process an attachment part and extract relevant information.
     
@@ -239,6 +239,7 @@ def process_attachment(part, depth, max_depth, container_path):
         depth (int): Current recursion depth
         max_depth (int): Maximum recursion depth
         container_path (list): Path of containers
+        stop_recursion (bool): If True, do not recursively parse embedded emails
         
     Returns:
         dict: Attachment information dictionary or None if it's an image

--- a/parsers/email_parser.py
+++ b/parsers/email_parser.py
@@ -174,7 +174,7 @@ def parse_email(
                                 depth + 1,
                                 max_depth,
                                 container_path + ["message/rfc822"],
-                                stop_recursion=True,
+                                stop_recursion=stop_recursion,
                             )
 
                             if embedded_email and "error" not in embedded_email:

--- a/tests/test_rfc822_stop_recursion.py
+++ b/tests/test_rfc822_stop_recursion.py
@@ -25,7 +25,7 @@ def build_simple_email(subject, body):
     return msg
 
 
-def test_rfc822_attachment_stops_recursion():
+def test_rfc822_attachment_recurses_to_inner():
     inner = build_simple_email('Inner', 'inner body')
 
     middle = build_simple_email('Middle', 'middle body')
@@ -38,8 +38,5 @@ def test_rfc822_attachment_stops_recursion():
 
     assert result.get('extraction_source') == 'rfc822_attachment'
     content = result['email_content']
-    assert content['subject'] == 'Middle'
-    assert len(content['attachments']) == 1
-    attachment = content['attachments'][0]
-    assert attachment['is_email'] is True
-    assert 'parsed_email' not in attachment
+    assert content['subject'] == 'Inner'
+    assert len(content['attachments']) == 0


### PR DESCRIPTION
## Summary
- allow parse_email to recurse into nested `message/rfc822` parts instead of forcing recursion stop
- propagate `stop_recursion` flag when extracting attachments
- update test to expect deepest message when RFC822 attachments nest

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6859fd216e488324a901f7748b903dd6