### PR TITLE
Add baseline unit tests

### DIFF
--- a/tests/test_body_extractor.py
+++ b/tests/test_body_extractor.py
@@ -1,0 +1,14 @@
+import pytest
+pytest.importorskip('bs4')
+
+from email.message import EmailMessage
+from extractors.body_extractor import extract_body
+
+
+def test_extract_body_plain():
+    msg = EmailMessage()
+    msg.set_content('plain text body')
+    result = extract_body(msg)
+    assert result['body'] == 'plain text body'
+
+

--- a/tests/test_header_extractor.py
+++ b/tests/test_header_extractor.py
@@ -1,0 +1,25 @@
+import email
+from email.message import EmailMessage
+from extractors.header_extractor import extract_headers
+
+
+def build_email():
+    msg = EmailMessage()
+    msg['Message-ID'] = '<id@example.com>'
+    msg['From'] = 'Alice <alice@example.com>'
+    msg['To'] = 'Bob <bob@example.com>'
+    msg['Subject'] = 'Test Subject'
+    msg['Date'] = 'Mon, 1 Jan 2024 10:00:00 -0000'
+    msg.set_content('Body')
+    return msg
+
+
+def test_extract_headers_basic():
+    msg = build_email()
+    headers = extract_headers(msg)
+    assert headers['subject'] == 'Test Subject'
+    assert headers['sender'] == 'Alice <alice@example.com>'
+    assert headers['receiver'] == 'Bob <bob@example.com>'
+    assert headers['message_id'] == '<id@example.com>'
+    assert headers['authentication'] == {'dkim': '', 'spf': '', 'dmarc': ''}
+

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -1,0 +1,13 @@
+import pytest
+
+jinja2 = pytest.importorskip('jinja2')
+
+from functions.html_report.generator import create_html
+
+
+def test_create_html_simple():
+    data = {'final_assessment': {'category': 'PHISHING', 'score': 5}}
+    html = create_html(data)
+    assert '<html' in html.lower()
+    assert 'PHISHING' in html
+

--- a/tests/test_json_cleaner_utils.py
+++ b/tests/test_json_cleaner_utils.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+# Provide minimal azure.functions stub for import
+azure_module = types.ModuleType('azure.functions')
+class _HR:  # minimal HttpRequest/HttpResponse
+    pass
+azure_module.HttpRequest = _HR
+azure_module.HttpResponse = _HR
+sys.modules.setdefault('azure', types.ModuleType('azure'))
+sys.modules.setdefault('azure.functions', azure_module)
+
+from functions.json_cleaner.cleaner import (
+    remove_markdown_notation,
+    sanitize_problematic_characters,
+    replace_nulls_with_none,
+)
+
+
+def test_remove_markdown_notation():
+    inp = "```json\n{\"a\":1}\n```"
+    assert remove_markdown_notation(inp) == '{"a":1}'
+
+
+def test_sanitize_problematic_characters():
+    inp = 'ab`cd\ff'
+    assert sanitize_problematic_characters(inp) == "ab'cd\\ff"
+
+
+def test_replace_nulls_with_none():
+    data = {"a": None, "b": [1, None]}
+    assert replace_nulls_with_none(data) == {"a": "None", "b": [1, "None"]}
+

--- a/tests/test_regex_extractor.py
+++ b/tests/test_regex_extractor.py
@@ -1,0 +1,26 @@
+import sys
+import types
+
+# Provide minimal azure.functions stub for import
+azure_module = types.ModuleType('azure.functions')
+class _HR:
+    pass
+azure_module.HttpRequest = _HR
+azure_module.HttpResponse = _HR
+sys.modules.setdefault('azure', types.ModuleType('azure'))
+sys.modules.setdefault('azure.functions', azure_module)
+
+from functions.regex_extractor.extractor import extract_with_regex
+
+
+def test_extract_with_regex_match():
+    value, error = extract_with_regex('hello 123 world', r'hello (\d+) world')
+    assert value == '123'
+    assert error is None
+
+
+def test_extract_with_regex_invalid_pattern():
+    value, error = extract_with_regex('test', r'[')
+    assert value is None
+    assert 'Invalid regex pattern' in error
+

--- a/tests/test_url_processing.py
+++ b/tests/test_url_processing.py
@@ -1,0 +1,29 @@
+import pytest
+pytest.importorskip('bs4')
+
+from utils.url_processing.extractor import UrlExtractor
+from utils.url_processing.processor import UrlProcessor
+from utils.url_processing.validator import UrlValidator
+
+
+def test_extract_urls_text():
+    text = 'See http://example.com and https://example.com/page.'
+    urls = UrlExtractor.extract_urls(text)
+    extracted = [u['original_url'] for u in urls]
+    assert 'http://example.com' in extracted
+    assert 'https://example.com/page' in extracted
+
+
+def test_validator_is_shortened():
+    assert UrlValidator.is_url_shortened('https://bit.ly/abc')
+    assert not UrlValidator.is_url_shortened('https://example.com')
+
+
+def test_url_processor_process_urls():
+    urls = ['http://example.com', 'http://example.com', 'https://bit.ly/abc']
+    processed = UrlProcessor.process_urls(urls)
+    originals = [u['original_url'] for u in processed]
+    assert originals.count('http://example.com') == 1
+    bitly = [u for u in processed if u['original_url'] == 'https://bit.ly/abc'][0]
+    assert bitly['is_shortened'] is True
+


### PR DESCRIPTION
## Summary
- add tests for header extractor
- add tests for body extractor, regex extractor, JSON cleaner utilities
- add tests for URL processing and HTML report generator
- skip tests that rely on missing optional dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0b12ac60832482e3fe9151dfe5f5