### PR TITLE
Enable stop_recursion flag in HTTP API

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -60,7 +60,11 @@ def parse_email_functionapp(req: func.HttpRequest) -> func.HttpResponse:
             pass
         
         # Parse the email - returns the original email data
-        parsed_data = parse_email(email_content, max_depth=max_depth)
+        parsed_data = parse_email(
+            email_content,
+            max_depth=max_depth,
+            stop_recursion=True,
+        )
         
         # Return the parsed data as JSON
         return func.HttpResponse(


### PR DESCRIPTION
## Summary
- ensure the function app does not recurse through attachments by enabling `stop_recursion`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac14ae4dc8324a77f3e4e64eacc36