### PR TITLE
Enable recursion control via parse_email HTTP endpoint

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -22,7 +22,11 @@ def parse_email_functionapp(req: func.HttpRequest) -> func.HttpResponse:
     
     Args:
         req (func.HttpRequest): HTTP request object
-        
+
+    Query Parameters:
+        max_depth (int): Maximum recursion depth. Defaults to 10.
+        stop_recursion (bool): If "true", disable recursive parsing. Defaults to False.
+
     Returns:
         func.HttpResponse: HTTP response with original email data in JSON format
     """
@@ -52,18 +56,27 @@ def parse_email_functionapp(req: func.HttpRequest) -> func.HttpResponse:
         
         # Get max depth parameter (default to 10)
         max_depth = 10
+        params = {}
         try:
             params = req.params
             if "max_depth" in params:
                 max_depth = int(params["max_depth"])
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, AttributeError):
             pass
         
+        # Determine whether to stop recursion (default False)
+        stop_recursion = False
+        try:
+            if params and "stop_recursion" in params:
+                stop_recursion = str(params["stop_recursion"]).lower() == "true"
+        except Exception:
+            pass
+
         # Parse the email - returns the original email data
         parsed_data = parse_email(
             email_content,
             max_depth=max_depth,
-            stop_recursion=True,
+            stop_recursion=stop_recursion,
         )
         
         # Return the parsed data as JSON

--- a/tests/test_parse_email_functionapp.py
+++ b/tests/test_parse_email_functionapp.py
@@ -1,0 +1,73 @@
+import sys
+import types
+import json
+import pytest
+
+bs4_available = True
+try:
+    from bs4 import BeautifulSoup  # noqa: F401
+except Exception:
+    bs4_available = False
+
+# Provide minimal azure.functions stub for import
+azure_module = types.ModuleType('azure.functions')
+class HttpRequest:
+    def __init__(self, body=b'', params=None):
+        self._body = body
+        self.params = params or {}
+    def get_body(self):
+        return self._body
+    def get_json(self):
+        return json.loads(self._body.decode('utf-8'))
+
+class HttpResponse:
+    def __init__(self, body=None, status_code=200, mimetype=None):
+        self.body = body
+        self.status_code = status_code
+        self.mimetype = mimetype
+    def get_body(self):
+        return self.body
+
+azure_module.HttpRequest = HttpRequest
+azure_module.HttpResponse = HttpResponse
+sys.modules.setdefault('azure', types.ModuleType('azure'))
+sys.modules.setdefault('azure.functions', azure_module)
+
+if bs4_available:
+    from email.message import EmailMessage
+    from function_app import parse_email_functionapp
+else:
+    EmailMessage = None  # type: ignore
+    parse_email_functionapp = None  # type: ignore
+
+pytestmark = pytest.mark.skipif(not bs4_available, reason="requires bs4")
+
+
+def build_simple_email(subject, body):
+    msg = EmailMessage()
+    msg['Subject'] = subject
+    msg['From'] = 'a@example.com'
+    msg['To'] = 'b@example.com'
+    msg.set_content(body)
+    return msg
+
+
+def test_http_endpoint_recurses_rfc822():
+    inner = build_simple_email('Inner', 'inner body')
+
+    middle = build_simple_email('Middle', 'middle body')
+    middle.add_attachment(inner.as_bytes(), maintype='message', subtype='rfc822')
+
+    outer = build_simple_email('Outer', 'outer body')
+    outer.add_attachment(middle.as_bytes(), maintype='message', subtype='rfc822')
+
+    req = HttpRequest(body=outer.as_bytes())
+
+    resp = parse_email_functionapp(req)
+    assert resp.status_code == 200
+
+    data = json.loads(resp.get_body())
+    assert data.get('extraction_source') == 'rfc822_attachment'
+    content = data['email_content']
+    assert content['subject'] == 'Inner'
+    assert len(content['attachments']) == 0


### PR DESCRIPTION
## Summary
- allow disabling recursion through `stop_recursion` query parameter in `parse_email_functionapp`
- document available query params in the function docstring
- add regression test covering recursive parsing of `message/rfc822` attachment via HTTP endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aca1573a08324b34b5f1f8ab116c2