### PR TITLE
Handle classification in HTML report

### DIFF
--- a/functions/html_report/generator.py
+++ b/functions/html_report/generator.py
@@ -59,7 +59,7 @@ def create_html(json_data):
                     <div style="margin-left: {{ indent * 20 }}px;">
                         <span class="json-key">{{ key | replace('_', ' ') | title }}:</span>
                         
-                        {% if key|lower == 'category' and value is string %}
+                        {% if key|lower in ['category', 'classification'] and value is string %}
                             <span class="category-tag" style="{{ category_styles.get(value|upper, category_styles['DEFAULT']) }}">
                                 {{ value|upper if value else 'N/A' }}
                             </span>

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -11,3 +11,11 @@ def test_create_html_simple():
     assert '<html' in html.lower()
     assert 'PHISHING' in html
 
+
+def test_create_html_classification():
+    data = {'decision': {'classification': 'SPAM', 'score': 2}}
+    html = create_html(data)
+    assert '<html' in html.lower()
+    assert 'SPAM' in html
+    assert 'category-tag' in html
+


### PR DESCRIPTION
## Summary
- support `classification` key for CSS category tag in HTML report generator
- test HTML generator with classification data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b04314af4832495fce56bdb804543