### PR TITLE
Improve handling of .msg attachments

### DIFF
--- a/extractors/attachment_extractor.py
+++ b/extractors/attachment_extractor.py
@@ -463,6 +463,18 @@ def process_attachment(part, depth, max_depth, container_path, stop_recursion=Fa
         
         if parsed_email:
             attachment["parsed_email"] = parsed_email
+            # If we successfully parsed an email, try to use its body as
+            # attachment_text when none was extracted above.
+            body_text = ""
+            if isinstance(parsed_email, dict):
+                if "email_content" in parsed_email and isinstance(
+                    parsed_email["email_content"], dict
+                ):
+                    body_text = parsed_email["email_content"].get("body", "")
+                else:
+                    body_text = parsed_email.get("body", "")
+            if body_text and not attachment_text:
+                attachment["attachment_text"] = body_text
         
         return attachment
         

--- a/extractors/body_extractor.py
+++ b/extractors/body_extractor.py
@@ -65,15 +65,19 @@ def extract_body(msg):
     else:
         content_type = msg.get_content_type().lower()
         logger.debug(f"Message is single part with content-type: {content_type}")
-        content = decode_content(msg)
-        logger.debug(f"Decoded content length: {len(content)}")
-        if len(content) > 0:
-            logger.debug(f"First 100 chars: {content[:100]}")
-        
-        if content_type == "text/plain":
-            plain_content = content
-        elif content_type == "text/html":
-            html_content = content
+
+        if content_type in ("text/plain", "text/html"):
+            content = decode_content(msg)
+            logger.debug(f"Decoded content length: {len(content)}")
+            if len(content) > 0:
+                logger.debug(f"First 100 chars: {content[:100]}")
+
+            if content_type == "text/plain":
+                plain_content = content
+            else:
+                html_content = content
+        else:
+            logger.debug("Skipping non-text single part content")
     
     # Create result dictionary with both plain text and HTML content
     result = {}

--- a/parsers/email_parser.py
+++ b/parsers/email_parser.py
@@ -52,8 +52,14 @@ def extract_basic_email_data(
         )
         attachments = [a for a in attachments if a is not None]
 
-        all_urls: List[str] = []
+        # Append text from attachments (e.g., parsed .msg) to body text for
+        # downstream processing
         body_text = body_data.get("body", "")
+        for att in attachments:
+            if att.get("attachment_text"):
+                body_text += "\n" + att["attachment_text"]
+
+        all_urls: List[str] = []
         all_urls.extend(UrlExtractor.extract_all_urls_from_email(body_data, body_text))
         all_urls.extend(UrlProcessor.extract_urls_from_attachments(attachments))
         processed_urls = UrlProcessor.process_urls(all_urls)

--- a/utils/text_cleaner.py
+++ b/utils/text_cleaner.py
@@ -5,14 +5,27 @@ from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
 
+
+def is_likely_html(text: str) -> bool:
+    """Simple heuristic to determine if text looks like HTML."""
+    if not text:
+        return False
+    if "\x00" in text:
+        return False
+    for c in text[:100]:
+        if ord(c) < 32 and c not in "\n\r\t":
+            return False
+    return True
+
 def strip_urls_and_html(text):
     if not text:
         return text
 
     #logger.debug(f"strip_urls_and_html text before html stripping: {text}")
-    # Remove HTML tags
-    soup = BeautifulSoup(text, "html.parser")
-    text = soup.get_text(separator=" ", strip=True)
+    if is_likely_html(text):
+        # Remove HTML tags
+        soup = BeautifulSoup(text, "html.parser")
+        text = soup.get_text(separator=" ", strip=True)
 
     # Remove raw URLs
     text = re.sub(r"\bhttps?://[\w\-._~:/?#@!$&'()*+,;=%]+", "", text)


### PR DESCRIPTION
## Summary
- skip non-text parts when extracting body
- capture body text from parsed `.msg` attachments
- include attachment text when extracting URLs and IPs
- avoid HTML parsing of binary data with `is_likely_html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3eabd6708324a888fd1861db6ecb