### PR TITLE
Fix IPv4 validation and docstring

### DIFF
--- a/extractors/ip_extractor.py
+++ b/extractors/ip_extractor.py
@@ -72,10 +72,17 @@ def is_valid_ipv4(ip):
             return False
     
     # Skip local/private IP addresses if needed
-    if (ip.startswith('127.') or
-         ip.startswith('10.') or
-         ip.startswith('172.16.') or
-         ip.startswith('192.168.')):
-         return False
+    if (
+        ip.startswith("127.")
+        or ip.startswith("10.")
+        or ip.startswith("192.168.")
+    ):
+        return False
+
+    # Cover the entire 172.16.0.0/12 private range (172.16.0.0 - 172.31.255.255)
+    if ip.startswith("172."):
+        second_octet = int(octets[1])
+        if 16 <= second_octet <= 31:
+            return False
     
     return True

--- a/function_app.py
+++ b/function_app.py
@@ -26,6 +26,7 @@ def parse_email_functionapp(req: func.HttpRequest) -> func.HttpResponse:
     Query Parameters:
         max_depth (int): Maximum recursion depth. Defaults to 10.
         stop_recursion (bool): If "true", disable recursive parsing. Defaults to False.
+        first_email_only (bool): If "true", only return the first parsed email. Defaults to True.
 
     Returns:
         func.HttpResponse: HTTP response with original email data in JSON format

--- a/functions/json_cleaner/cleaner.py
+++ b/functions/json_cleaner/cleaner.py
@@ -5,8 +5,8 @@ import azure.functions as func
 
 logger = logging.getLogger(__name__)
 
-# Set up logging configuration
-logging.basicConfig(level=logging.DEBUG)
+# In the Azure Functions environment the host configures logging. Avoid
+# overriding it here so we simply obtain a module level logger.
 
 def remove_markdown_notation(input_string):
     logger.debug("Starting markdown notation removal.")


### PR DESCRIPTION
## Summary
- expand private IP range check in `is_valid_ipv4`
- document `first_email_only` query parameter
- avoid overriding logging configuration in JSON cleaner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c26cad194832483e8c237652a5d4f